### PR TITLE
Update hmpo-frontend-toolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "express-partial-templates": "^0.2.0",
     "express-session": "^1.14.0",
     "hmpo-form-wizard": "^5.1.0",
-    "hmpo-frontend-toolkit": "UKHomeOffice/passports-frontend-toolkit#feature/new-modules",
+    "hmpo-frontend-toolkit": "^7.0.0",
     "hmpo-template-mixins": "^4.5.0",
     "hmpo-templates": "^1.0.0",
     "hogan-express-strict": "^0.5.4",


### PR DESCRIPTION
The toolkit has been updated with more styles, use the release version now that the feature branch version has been merged.
