### PR TITLE
Remove As written in your passport in the title page

### DIFF
--- a/views/prototype_161110/renew/title.html
+++ b/views/prototype_161110/renew/title.html
@@ -11,7 +11,6 @@
 {{< hmpo-partials-form}}
 {{$form}}
 <fieldset class="inline">
-    <p>As written on your passport.</p>
     {{#radio-group}}title{{/radio-group}}
     <div id="other-titles" class="reveal js-hidden">
         <div class="panel panel-border-narrow">


### PR DESCRIPTION
As it’s not actually in the passport