### PR TITLE
Don't crop page

### DIFF
--- a/views/prototype_161124/photoguide-short/short-crop.html
+++ b/views/prototype_161124/photoguide-short/short-crop.html
@@ -2,7 +2,7 @@
 
 {{$back}}
 <div class="photo-guide">
-            <a href="/../prototype_161110/intro/choose-photo-method" class="back-link">Other ways to get a photo</a>
+            <a href="/../prototype_161110/intro/choose-photo-method" class="back-link">Include your shoulders and upper body</a>
             <span class="marker">Guide part 5 of 6</span>
         </div>
 {{/back}}
@@ -13,12 +13,12 @@
         <div class="column-full">
             <div class="flash-card">
                 <header>
-                    <h1>We'll crop your photo</h1>
+                    <h1>Include your shoulders and upper body</h1>
                 </header>
                 <div class="grid-row">
                     <div class="column-half">
-                    <p>It's difficult to crop your photo correctly. Don't crop your photo, we'll do it for you.</p>
-                      <p>Make sure there’s enough room around your head and shoulders. The person taking the photo may have to move if there's not.
+                      <p>Your photo must show your head, shoulders and upper body.
+                         <p><strong>Don't crop your photo - we'll do it for you.</strong></p>
                     </div>
                     <div class="column-half">
                       <img src="../../public/images/photoguide/diagram_too_close_photo@2x.png"  alt="" width="333" height="288">

--- a/views/prototype_161124/photoguide-short/short-right-position.html
+++ b/views/prototype_161124/photoguide-short/short-right-position.html
@@ -17,7 +17,6 @@
                </header>
               <div class="grid-row">
                    <div class="column-half">
-                     <p><strong>Your photo must show your head, shoulders and upper body.</strong></p>
                      <p>To avoid shadows, stand 50 centimetres away from your plain background.</p>
                      <p>The person taking your photo needs to stand 1.5 metres away from you.</p>
                    </div>
@@ -37,7 +36,7 @@
                                        <a href="{{backLink}}">Back</a>
                                    </li>
                                    <li class="button-guide button-guide-next">
-                                       <a href="{{nextPage}}">We'll crop your photo</a>
+                                       <a href="{{nextPage}}">Include your shoulders and upper body</a>
                                    </li>
                                </ul>
                    </nav>


### PR DESCRIPTION
Head, shoulders body message deleted from ‘Stand in the right position’.
Content changed on the ‘Don’t crop’ page.