### PR TITLE
H2 content on get yourself ready

### DIFF
--- a/views/prototype_161124/photoguide-short/short-rules-1.html
+++ b/views/prototype_161124/photoguide-short/short-rules-1.html
@@ -18,48 +18,50 @@
               </header>
               <div class="grid-row">
                   <div class="column-full">
-                     <p>Remove any headwear, unless you’re wearing it for religious or medical reasons.</p>
+                    <h2>Remove headwear</h2>
+                     <p>If you wear it for religious or medical reasons, you can keep it on.</p>
                     <div class="guidance-photos" aria-hidden="true">
                         <ul>
                             <li>
                                 <img src="../../public/images/photoguide/image-f2-religious-head-covering.jpg" alt="">
                                 <div class="result" style="height: 57px;">
-                                    <p class="approved">Approved</p>
+                                    <p class="approved">Religious headwear</p>
                                 </div>
                             </li>
                             <li>
                                 <img src="../../public/images/photoguide/image-m3-head-covering.jpg" alt="">
                                 <div class="result" style="height: 57px;">
-                                    <p class="failed">No fashion hair covering</p>
+                                    <p class="failed">Fashion headwear</p>
                                 </div>
                             </li>
                             <li>
                                 <img src="../../public/images/photoguide/image-f1-hair-accessory.jpg" alt="">
                                 <div class="result" style="height: 57px;">
-                                    <p class="failed">No hair accessories</p>
+                                    <p class="failed">Hair accessories</p>
                                 </div>
                             </li>
                         </ul>
                     </div>
-                    <p>Keep your hair away from your face and brushed down.<br>Your face and eyes must be visible.</p>
+                    <h2>Keep your face clear</h2>
+                    <p>Your hair must be away from your face and brushed down.</p>
                     <div class="guidance-photos" aria-hidden="true">
                           <ul>
                               <li>
                                   <img src="../../public/images/photoguide/image-f1-plain.jpg" alt="">
                                   <div class="result" style="height: 57px;">
-                                      <p class="approved">Approved</p>
+                                      <p class="approved">Face and eyes visible</p>
                                   </div>
                               </li>
                               <li>
                                   <img src="../../public/images/photoguide/image-f1-hair-over-eye.jpg" alt="">
                                   <div class="result" style="height: 57px;">
-                                      <p class="failed">Keep hair away from eyes</p>
+                                      <p class="failed">Hair on face</p>
                                   </div>
                               </li>
                               <li>
                                   <img src="../../public/images/photoguide/image-f2-headscarf-covering-eye.jpg" alt="">
                                   <div class="result" style="height: 57px;">
-                                      <p class="failed">Avoid covering face</p>
+                                      <p class="failed">Religious headwear on face</p>
                                   </div>
                               </li>
                           </ul>


### PR DESCRIPTION
Added H2 subheads. Need to reinstate all sections with ‘Take your
glasses off’ on the ‘Get yourself ready’ page.