### PR TITLE
Remove the photo shop guide from get a digital photo page

### DIFF
--- a/routes/prototype_161212/intro/fields.js
+++ b/routes/prototype_161212/intro/fields.js
@@ -27,6 +27,29 @@ module.exports = {
           redirect:'/../upload'
         }
       ]
+    },
+    'choose-photo-overseas': {
+      legend: {
+        value: 'What are you trying to do?',
+        className: 'visuallyhidden'
+      },
+      options: [
+        {value: 'myself', label: 'Show me how to do it myself'},
+        {value: 'upload', label: 'I already have a digital photo'}
+      ],
+      validate: [
+        'required',
+        {
+          type:'equal',
+          arguments:['upload','shop'],
+          redirect:'/../photoguide-short'
+        },
+        {
+          type:'equal',
+          arguments:['upload','upload'],
+          redirect:'/../upload'
+        }
+      ]
     }
 
 };

--- a/routes/prototype_161212/intro/steps.js
+++ b/routes/prototype_161212/intro/steps.js
@@ -9,7 +9,7 @@ module.exports = {
     },
     '/what-you-need-overseas': {
       backLink: './',
-      next: '/choose-photo-method'
+      next: '/choose-photo-method-overseas'
     },
     '/you-need-a-photo': {
       backLink: './what-you-need',
@@ -25,6 +25,10 @@ module.exports = {
     },
     '/choose-photo-method': {
       fields: ['choose-photo'],
+      next: '/../upload'
+    },
+    '/choose-photo-method-overseas': {
+      fields: ['choose-photo-overseas'],
       next: '/../upload'
     }
 };

--- a/views/prototype_161212/intro/choose-photo-method-overseas.html
+++ b/views/prototype_161212/intro/choose-photo-method-overseas.html
@@ -1,0 +1,47 @@
+{{< layout}}
+
+{{$pageTitle}}Get your digital photo{{/pageTitle}}
+
+{{$header}}
+    <h1>Get your digital photo</h1>
+{{/header}}
+
+{{$content}}
+
+    {{< hmpo-partials-form}}
+    {{$form}}
+            <div id="choose-photo-overseas-group" class="form-group{{#errors.choose-photo}} error{{/errors.choose-photo}}">
+                <fieldset role="radiogroup" aria-required="upload">
+                    <legend>
+                        <span class="form-label">You can take your photo and upload it. We'll show you how. <br>
+                        Or, you can get your photo from a shop.</span>
+                        {{#errors.choose-photo}}<span id="{{key}}-error" class="error-message">{{errors.choose-photo.message}}</span>{{/errors.choose-photo}}
+                    </legend>
+                    <label class="block-label" for="choose-photo-overseas-myself">
+                        <input type="radio" name="choose-photo-overseas" id="choose-photo-overseas-myself" value="myself" aria-required="upload"{{#selected}}choose-photo-overseas=myself{{/selected}}{{#errors.choose-photo}} aria-describedby="{{key}}-error" aria-invalid="upload"{{/errors.choose-photo}}>
+                        Show me how to take a passport photo
+                    </label>
+                    <div style="clear:both"></div><br/>
+                    <h2>I have a digital photo</h2>
+                    <p class="form-block">Your photo needs to meet the <a href="/../prototype_161212/photoguide-short"> rules for passport photos</a>.</p>
+                    <label class="block-label" for="choose-photo-overseas-upload">
+                        <input type="radio" name="choose-photo-overseas" id="choose-photo-overseas-upload" value="upload" aria-required="upload"{{#selected}}choose-photo-overseas=upload{{/selected}}{{#errors.choose-photo}} aria-describedby="{{key}}-error" aria-invalid="upload"{{/errors.choose-photo}}>
+                        Upload a photo
+                    </label>
+                </fieldset>
+            </div>
+            {{#input-submit}}{{/input-submit}}
+            <details>
+                <summary><span class="summary">I have a printed passport photo</span></summary>
+                <div class="panel panel-border-narrow">
+                  <p>You’ll need to post your printed photo with your old passport.</p>
+                  <p>We’ll check your photo. Your application will be delayed if we have to ask you for a different one.</p>
+                  <p><a href="/../prototype_161212/renew-without-photo">Apply with a printed photo</a></p>
+                </div>
+            </details>
+        {{/form}}
+    {{/ hmpo-partials-form}}
+
+{{/content}}
+
+{{/ layout}}


### PR DESCRIPTION
Creating another "Get a digital photo" page that does not contain the photo shops guide & linking into it