### PR TITLE
Removed 'standard' passport

### DIFF
--- a/views/priority_service_170202/get-urgent-passport/fast-track.html
+++ b/views/priority_service_170202/get-urgent-passport/fast-track.html
@@ -21,7 +21,7 @@
 </ol>
 <p>Your new passport will arrive in the post within 1 week of your appointment.</p>
 
-<p>Using this service, a standard adult passport costs £103 and a child passport costs £87. </p>
+<p>Using this service, an adult passport costs £103 and a child passport costs £87. </p>
 
 <td><h2><a href=""><input class="button" type="submit" value="Book an appointment"></h2></a></td>
 

--- a/views/priority_service_170202/get-urgent-passport/index.html
+++ b/views/priority_service_170202/get-urgent-passport/index.html
@@ -51,7 +51,7 @@
 		</tr>
 
     <tr>
-      <td class="criterion"><span class="bold-small">How much does a standard adult passport cost?</span></td>
+      <td class="criterion"><span class="bold-small">How much does an adult passport cost?</span></td>
       <td>£128</div></td>
       <td>£128</td>
       <td>£103</td>

--- a/views/priority_service_170202/get-urgent-passport/premium-offline.html
+++ b/views/priority_service_170202/get-urgent-passport/premium-offline.html
@@ -20,7 +20,7 @@
 <li>Book an appointment</a> to drop off your completed form and photos </li>
 <li> Collect your new passport 4 hours later </li>
 </ol>
-<p>A standard adult passport costs £128 using this service. If you're applying for <br>
+<p>An adult passport costs £128 using this service. If you're applying for <br>
  a child passport, you need to use <a href="/priority_service_170202/get-urgent-passport/fast-track">Fast Track</a>.
 
 <td><h2><a href=""><input class="button" type="submit" value="Book an appointment"></h2></a></td>

--- a/views/priority_service_170202/get-urgent-passport/premium-online.html
+++ b/views/priority_service_170202/get-urgent-passport/premium-online.html
@@ -23,7 +23,7 @@
 <li>Take and upload a digital photo - we'll show you how</li>
 <li>Attend your appointment to collect your new passport</li>
 </ol>
-<p>A standard adult passport costs £128 using this service. If you're applying for <br>a child passport, you need to use <a href="/priority_service_170202/get-urgent-passport/fast-track">Fast Track</a>.
+<p>An adult passport costs £128 using this service. If you're applying for <br>a child passport, you need to use <a href="/priority_service_170202/get-urgent-passport/fast-track">Fast Track</a>.
 
 <td><h2><a href="/priority_service_170202/filter-common"><input class="button" type="submit" value="Continue"></h2></a></td>
 

--- a/views/priority_service_170202/intro/what-you-need-overseas.html
+++ b/views/priority_service_170202/intro/what-you-need-overseas.html
@@ -16,7 +16,7 @@
                               <li><span class="circle circle-step">2</span><h2>Apply online</h2>
                                 <p style="margin-left:32px;">You'll need to check the details in your old passport.</p></li>
                               <li><span class="circle circle-step">3</span><h2>Pay for your new passport</h2>
-                                <p style="margin-left:32px;">A standard passport is £83 plus £19.86 for delivery by courier. </p>
+                                <p style="margin-left:32px;">An adult passport is £83 plus £19.86 for delivery by courier. </p>
                               </li>
                               <li><span class="circle circle-step">4</span><h2>Send us your old passport</h2>
                                 <p  style="margin-left:32px;">You need to pay the postage to return your old passport.</p>

--- a/views/priority_service_170202/intro/what-you-need.html
+++ b/views/priority_service_170202/intro/what-you-need.html
@@ -18,7 +18,7 @@
                                 <p style="margin-left:32px;">You'll need to take a digital photo - we'll show you how.</p>
                               </li>
                               <li><span class="circle circle-step">3</span><h2>Pay for your new passport online</h2>
-                                <p  style="margin-left:32px;">A standard adult passport using this service is £128.</p>
+                                <p  style="margin-left:32px;">An adult passport using this service is £128.</p>
                               </li>
                               <li><span class="circle circle-step">4</span><h2>Collect your new passport</h2>
                                 <p  style="margin-left:32px;">You'll need to go in person and take your old passport with you.</p>


### PR DESCRIPTION
As agreed with Has, we don’t need ‘standard’ before ‘standard adult
passport’.