### PR TITLE
PEXRD 487 488 493

### DIFF
--- a/views/damaged_171018/renew/confirmation.html
+++ b/views/damaged_171018/renew/confirmation.html
@@ -10,7 +10,8 @@
 
     <header class="update-notice">
       <h1><span class="icon-tick"></span>Payment successful</h1>
-          <p>You have paid £72.50. Your payment reference is IE19852.</p>
+          <p>You have paid £72.50. Your payment reference is IE19852.<br>
+            We'll email you a receipt. You can also download a copy.</p>
       <a href="" class="download">Download PDF receipt</a>
     </header>
 

--- a/views/damaged_171018/renew/read-passport-number.html
+++ b/views/damaged_171018/renew/read-passport-number.html
@@ -19,9 +19,8 @@
       {{#input-text}}what-damaged{{/input-text}}
     <div class="form-group">
       <label class="form-label-bold" for="textarea">
-        How did this happen?
+        Describe what happened to your passport
       </label>
-      <span class="form-hint">Give as much detail as you can.</span>
       {{#textarea}}how-damaged{{/textarea}}
     </div>
 

--- a/views/damaged_171018/startpage/index.html
+++ b/views/damaged_171018/startpage/index.html
@@ -5,16 +5,15 @@
 {{$pageTitle}}Apply for, renew or replace a UK passport{{/pageTitle}}
 
 {{$header}}
-    <h1>Apply for, renew or change a UK passport online</h1>
+    <h1>Apply online for a UK passport</h1>
 {{/header}}
 
 
 {{$content}}
     <p>
-    We'll ask you a few questions to check which service you need.
-    </p>
+  You can apply for, replace or update your passport and pay for it online.</p>
     <p id="get-started" class="get-started group">
-      <a href="/../damaged_171018/filter-common" class="big button js-gaevent" role="button" data-gakey="start" data-galabel="or">Continue</a>
+      <a href="/../damaged_171018/filter-common" class="big button js-gaevent" role="button" data-gakey="start" data-galabel="or">Start now</a>
     </p>
     <br/>
 

--- a/views/govuk/damaged/damaged-examples.html
+++ b/views/govuk/damaged/damaged-examples.html
@@ -26,7 +26,7 @@
       Examples of damaged passports
         </li>
         <li>
-          <a href="/govuk/damaged/damaged-renew">What to do if your passport is damaged</a>
+          <a href="/govuk/damaged/damaged-renew">Replace a damaged passport</a>
         </li>
     </ol>
   </nav>

--- a/views/govuk/damaged/damaged-renew.html
+++ b/views/govuk/damaged/damaged-renew.html
@@ -20,22 +20,25 @@
       <a href="/govuk/damaged/damaged-examples">Examples of damaged passports</a>
       </li>
       <li>
-        What to do if your passport is damaged
+        Replace a damaged passport
       </li>
     </ol>
   </nav>
 </aside>
 
     <h1 class="part-title">
-    3. What to do if your passport is damaged</h1>
-    <p>If your passport is damaged, you must get a new one. Find out how to <a href="https://www.gov.uk/renew-adult-passport">apply for a new passport</a>.</p>
+    3. Replace a damaged passport</h1>
+    <p>If your passport is damaged, you must get a new one before you travel.</p>
+    <p>An adult passport costs £72.50. A child passport costs £46. If your damaged passport hasn't expired, you'll get up to 9 months added to your new passport.</p>
+
+    <p>You can get a new passport by completing a form from the Post Office or you can <a href="https://www.gov.uk/apply-renew-passport">apply online</a>.</p>
+
+    <p>It usually takes 3 weeks to get a new passport. If you need one sooner, use the <a href="https://www.gov.uk/get-a-passport-urgently">Fast Track (1 week) service</a>.</p>
 
     <br>
       <div class="panel panel-border-wide">
       <p>You may not be allowed to leave or enter the UK if you travel with a damaged passport.</p></div>
-    <br>
-
-</div>
+    <br></div>
 
 </div>
 {{/content}}

--- a/views/govuk/damaged/index.html
+++ b/views/govuk/damaged/index.html
@@ -26,7 +26,7 @@
         <a href="/govuk/damaged/damaged-examples">Examples of damaged passports</a>
         </li>
         <li>
-          <a href="/govuk/damaged/damaged-renew">What to do if your passport is damaged</a>
+          <a href="/govuk/damaged/damaged-renew">Replace a damaged passport</a>
         </li>
     </ol>
   </nav>


### PR DESCRIPTION
H1 on damaged start page
Removed ‘renew’ in intro line
Changed ‘how did this happen’ field label
Improved content of Gov.uk damaged pages