### PR TITLE
Email and how to page edits

### DIFF
--- a/static/emails/csig-email-12.html
+++ b/static/emails/csig-email-12.html
@@ -49,8 +49,8 @@ li {
 
                         <h2>How to do this</h2>
 
-                        <p>You can confirm someone's identity online. It takes about 10 minutes.
-                        We'll ask you a few questions then show you a photo. <br> You don't need to sign a printed photo.</p>
+                        <p>You can confirm someone's identity online. We'll ask you for a few details to check your identity.</p>
+                        <p>Once your identity is confirmed, we'll show you a photo. You don't need to sign a printed photo.</p>
                         </p>
                         <h2>What you need</h2>
 
@@ -59,19 +59,14 @@ li {
                          <ul>
                            <li>to know David's date of birth, including the year</li>
                             <li>this reference: 896 345 1083</li>
-                          </ul>
-                          <br>
-                          <p>To confirm who you are, you also need your:</p>
-
-                          <ul>
-                            <li>current UK passport</li>
-                            <li>National Insurance number</li>
                          </ul>
+
+                         <p>You'll also need your current UK passport.</p>
 
 
                          <h2>When to do this</h2>
 
-                          <p>Please do this as soon as possible. We can't print David's new passport until his identity is confirmed.</p>
+                          <p>Please do this as soon as possible. It takes about 10 minutes. We can't print David's new passport until his identity is confirmed.</p>
                           <p> Go to <a href="/csig_171101/referee-5">http://gov.uk/confirm-identity/3w12aq7</a></p>
 
                           Please don't reply to this email - it's an automatic message from an unmonitored account.

--- a/views/csig_170921/user/csig-requirements.html
+++ b/views/csig_170921/user/csig-requirements.html
@@ -20,10 +20,10 @@
               </ul>
 
             <span class="circle circle-step">2</span><h2>Contact the person</h2>
-            <p style="margin-left:32px;">You must contact the person before we send them an email with your details. Tell them:</p>
+            <p style="margin-left:32px;">You must contact the person before we send them an email with your details. You need to tell them:</p>
             <ul class="list-bullet" style="margin-left:32px;">
               <li>your date of birth including the year</li>
-              <li>they need their UK passport and National Insurance number</li>
+              <li>they need their UK passport</li>
             </ul>
 
             </li>

--- a/views/csig_171101/csig/index.html
+++ b/views/csig_171101/csig/index.html
@@ -20,10 +20,10 @@
               </ul>
 
             <span class="circle circle-step">2</span><h2>Contact the person</h2>
-            <p style="margin-left:32px;">You must contact the person before we send them an email with your details. Tell them:</p>
+            <p style="margin-left:32px;">You must contact the person before we send them an email with your details. You need to tell them:</p>
             <ul class="list-bullet" style="margin-left:32px;">
               <li>your date of birth including the year</li>
-              <li>they need their UK passport and National Insurance number</li>
+              <li>they need their UK passport</li>
             </ul>
 
             </li>

--- a/views/csig_171101/referee-5/index.html
+++ b/views/csig_171101/referee-5/index.html
@@ -22,7 +22,9 @@
 
         </ul>
 
-        <p>We'll ask you a few questions then show you a photo of the person. It takes about 10 minutes.</p>
+        <p>We'll ask you for a few details to check your identity. Then we'll show you a photo of the person.</p>
+
+        <p>It takes about 10 minutes.</p>
 
 
         <a href="/csig_171101/referee-5/applicant-info" class="button">Start</a>
@@ -41,11 +43,10 @@
 <div class="column-one-third">
     <div class="sidebar" style="margin-top:50px">
       <div class="photo-preview-inner">
-          <h2 class="heading-medium">What you'll need</h2>
+          <h2 class="heading-medium">What you need</h2>
           <ul class="list-bullet" >
             <li style="list-style-type: disc;"> your current UK passport</li>
-            <li>National Insurance number</li>
-            <li>employer's details</li>
+            <li>your employer's details</li>
           </ul>
           <p><a href="/govuk/" target="_blank">Read more on GOV.UK</a></p>
       </div>


### PR DESCRIPTION
Removed ‘National Insurance number’ from email to Csig and blue ‘how
to’ page.
Added a message to Csig email and start page about ‘asking for details
that we’ll use to check your identity’